### PR TITLE
Bump version, initCircularRegionWithCenter deprecated as of iOS7 and some warnings

### DIFF
--- a/GeoHashObjC.podspec
+++ b/GeoHashObjC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "GeoHashObjC"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "GeoHash implementation in Objective-C for iOS"
   s.homepage     = "https://github.com/dominikweifieg/GeoHashObjC"
   s.license = { :type => 'MIT', :text => <<-LICENSE

--- a/GeoHashObjC/GeoHashObjC.m
+++ b/GeoHashObjC/GeoHashObjC.m
@@ -107,7 +107,7 @@ NSDictionary *_borders;
     double lat = rect.ne.latitude + (rect.sw.latitude - rect.ne.latitude);
     double lng = rect.ne.longitude + (rect.sw.longitude - rect.ne.longitude);
     CLLocationDistance dist = [[[CLLocation alloc] initWithLatitude:lat longitude:lng] distanceFromLocation:[[CLLocation alloc] initWithLatitude:rect.ne.latitude longitude:rect.ne.longitude]];
-    CLRegion *result = [[CLRegion alloc] initCircularRegionWithCenter:CLLocationCoordinate2DMake(lat, lng) radius:dist/2 identifier:geohash];
+    CLRegion *result = [[CLCircularRegion alloc] initWithCenter:CLLocationCoordinate2DMake(lat, lng) radius:dist/2 identifier:geohash];
     return result;
 }
 

--- a/GeoHashObjC/GeoHashObjC.m
+++ b/GeoHashObjC/GeoHashObjC.m
@@ -80,7 +80,7 @@ NSDictionary *_borders;
     NSUInteger length = [geohash length];
     for (int i=0; i<length; i++) {
         NSString *c = [geohash substringWithRange:NSMakeRange(i, 1)];
-        int cd = [_gh_base_32 rangeOfString:c].location;
+        int cd = (int)[_gh_base_32 rangeOfString:c].location;
         for (int j=0; j<5; j++) {
             int mask = GH_BITS[j];
             if (even) {


### PR DESCRIPTION
Cleaned up some random warnings and removed deprecated use of initCircularRegionWithCenter
